### PR TITLE
Fix iOS AppCenter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For this reference app scenario, we built several consumer and line-of-business 
 You can also download the mobile apps connected to our public endpoints in your devices following these links:
 
 * [![Build status](https://build.appcenter.ms/v0.1/apps/3dfdc914-1b68-46aa-83c0-d89aa1a8c728/branches/master/badge)](https://appcenter.ms) [SmartHotel360 Android Client App](https://aka.ms/smarthotel360android) 
-* [![Build status](https://build.appcenter.ms/v0.1/apps/27f92278-1c34-40c3-815c-adb5d6355165/branches/master/badge)](https://appcenter.ms) [SmartHotel360 iOS Client App](https://aka.ms/smarthotel360ios)
+* [![Build status](https://build.appcenter.ms/v0.1/apps/27f92278-1c34-40c3-815c-adb5d6355165/branches/master/badge)](https://appcenter.ms) [SmartHotel360 iOS Client App](https://install.appcenter.ms/orgs/appcenterdemos/apps/smarthotel360ios/distribution_groups/public)
 * [![Build status](https://build.appcenter.ms/v0.1/apps/2a0e7f37-0864-47c2-b053-756affd51f99/branches/master/badge)](https://appcenter.ms) [SmartHotel360 UWP Client App](https://aka.ms/smarthotel360uwp) 
 * [![Build status](https://build.appcenter.ms/v0.1/apps/9f75cc13-cc2e-4350-baaa-6913c6116848/branches/master/badge)](https://appcenter.ms) [SmartHotel360 NFC Android App](https://aka.ms/smarthotel360nfc) 
 * [![Build status](https://build.appcenter.ms/v0.1/apps/e9e59729-c5a3-49ff-a92a-5ae9c3b5fb72/branches/master/badge)](https://appcenter.ms) [SmartHotel360 iOS Maintenance App](https://aka.ms/smarthotel360maintenance)


### PR DESCRIPTION
**This link:**
https://aka.ms/smarthotel360ios

**doesn't go to the intended place:**
https://install.appcenter.ms/orgs/appcenterdemos/apps/smarthotel360ios/distribution_groups/public

**instead, it goes to**
https://install.appcenter.ms/orgs/smarthotel360-iot/apps/smarthotel360-iot-ios/distribution_groups/public

Fix that shortened URL **or** approve this PR. The first option is preferred.

Thanks!